### PR TITLE
SystemOrder is missing total discount

### DIFF
--- a/src/DTO/SystemOrder.php
+++ b/src/DTO/SystemOrder.php
@@ -41,6 +41,7 @@ class SystemOrder extends Order implements JsonSerializable, DTOInterface
     public ?float $tax;
     public ?string $tax_display;
     public ?float $total;
+    public ?float $total_discount;
     public ?string $total_discount_display;
     public ?string $total_display;
 
@@ -82,6 +83,7 @@ class SystemOrder extends Order implements JsonSerializable, DTOInterface
         $this->tax                    = self::floatFrom($data, "tax");
         $this->tax_display            = self::stringFrom($data, "tax_display");
         $this->total                  = self::floatFrom($data, "total");
+        $this->total_discount         = self::floatFrom($data, "total_discount");
         $this->total_discount_display = self::stringFrom($data, "total_discount_display");
         $this->total_display          = self::stringFrom($data, "total_display");
     }

--- a/tests/DTO/SystemOrderTest.php
+++ b/tests/DTO/SystemOrderTest.php
@@ -264,6 +264,7 @@ class SystemOrderTest extends TestCase
             "tax": 11.11,
             "tax_display": "tax_display",
             "total": 12.12,
+            "total_discount": 0.00,
             "total_discount_display": "total_discount_display",
             "total_display": "total_display"
         }';


### PR DESCRIPTION
@flumonion it seems we're missing the `total_discount` field on the `SystemOrder`, we have a field `total_discount_display` but no actual value for it. 

This PR adds the `total_discount` property to the `DTO`.

Tests are passing, Psalm has no issues