### PR TITLE
dateStringFrom for created and modified

### DIFF
--- a/src/DTO/Channel.php
+++ b/src/DTO/Channel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stock2Shop\Share\DTO;
 
 use JsonSerializable;
+use Stock2Shop\Share\Utils\Date;
 
 class Channel extends DTO implements JsonSerializable, DTOInterface
 {
@@ -27,11 +28,11 @@ class Channel extends DTO implements JsonSerializable, DTOInterface
 
         $this->active           = self::boolFrom($data, 'active');
         $this->client_id        = self::intFrom($data, 'client_id');
-        $this->created          = self::stringFrom($data, 'created');
+        $this->created          = self::dateStringFrom($data, 'created',Date::FORMAT);
         $this->description      = self::stringFrom($data, 'description');
         $this->id               = self::intFrom($data, 'id');
         $this->meta             = $this->sortArray($meta, "key");
-        $this->modified         = self::stringFrom($data, 'modified');
+        $this->modified         = self::dateStringFrom($data, 'modified',Date::FORMAT);
         $this->price_tier       = self::stringFrom($data, 'price_tier');
         $this->qty_availability = self::stringFrom($data, 'qty_availability');
         $this->sync_token       = self::stringFrom($data, 'sync_token');

--- a/src/Utils/Date.php
+++ b/src/Utils/Date.php
@@ -12,7 +12,7 @@ use InvalidArgumentException;
 class Date
 {
     // might not need FORMAT without microseconds
-//    public const FORMAT = "Y-m-d H:i:s";
+    public const FORMAT = "Y-m-d H:i:s";
     public const FORMAT_MS = "Y-m-d H:i:s.u";
     public const TIMEZONE = "UTC";
 
@@ -29,8 +29,8 @@ class Date
      */
     public static function getDateString($date = '', $format = self::FORMAT_MS): string
     {
-        if ($format != self::FORMAT_MS) {
-            throw new InvalidArgumentException('Invalid Date Format');
+        if ($format != self::FORMAT_MS && $format != self::FORMAT) {
+                throw new InvalidArgumentException('Invalid Date Format');
         }
         date_default_timezone_set(self::TIMEZONE);
         if (is_string($date)) {


### PR DESCRIPTION
@flumonion Please see the change I have made here

I do understand that we may not need to validate the string as it will be our system creating those dates, but perhaps this is best practice, especially since we are not using DateTime types.

Can I also refactor [this](https://github.com/stock2shop/share/blob/8bcd9ab38a0e46dc5e6ee45e071bb00ca2e4df99/src/Utils/Date.php#L42-L43) to be a `elseif`?

I would like to make sure I am on the right track, noting that everything else on the Channel DTO looks correct and nothing is missing.